### PR TITLE
[prometheus-artifactory-exporter] Bump the chart version

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -7,18 +7,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v2.0
         with:
-          version: v3.5.0
+          version: v3.8.1
+
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
+
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.2.1
+
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
@@ -26,10 +30,19 @@ jobs:
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
+
+      - name: install helm unittest plugin
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          helm env
+          helm plugin install https://github.com/quintush/helm-unittest.git --version 0.2.8
+
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml
+
       - name: Create kind cluster
-        uses: helm/kind-action@v1.1.0
+        uses: helm/kind-action@v1.2.0
+
         if: steps.list-changed.outputs.changed == 'true'
       - name: Run chart-testing (install)
         run: ct install --config ct.yaml

--- a/charts/prometheus-artifactory-exporter/Chart.yaml
+++ b/charts/prometheus-artifactory-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.9.1"
+appVersion: "1.9.3"
 description: A Helm chart for the Prometheus Artifactory Exporter
 name: prometheus-artifactory-exporter
-version: 0.1.4
+version: 0.1.5
 keywords:
   - metrics
   - artifactory

--- a/charts/prometheus-artifactory-exporter/Chart.yaml
+++ b/charts/prometheus-artifactory-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.9.3"
 description: A Helm chart for the Prometheus Artifactory Exporter
 name: prometheus-artifactory-exporter
-version: 0.1.5
+version: 0.2.0
 keywords:
   - metrics
   - artifactory

--- a/charts/prometheus-artifactory-exporter/values.yaml
+++ b/charts/prometheus-artifactory-exporter/values.yaml
@@ -16,9 +16,10 @@ serviceAccount:
   name:
 
 image:
-  registry: docker.io
+  registry: ghcr.io
   repository: peimanja/artifactory_exporter
-  tag: v1.9.1
+  # set to canary for the latest unreleased version
+  tag: v1.9.3
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
#### What this PR does / why we need it:
- Switch to Github registry https://github.com/peimanja/artifactory_exporter/pkgs/container/artifactory_exporter
- Bump the chart version
#### Checklist
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-artifactory-exporter]`)
