### PR TITLE
[prometheus-artifactory-exporter] Add ability to enable optional metrics

### DIFF
--- a/charts/prometheus-artifactory-exporter/Chart.yaml
+++ b/charts/prometheus-artifactory-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.9.5"
+appVersion: "1.10.0"
 description: A Helm chart for the Prometheus Artifactory Exporter
 name: prometheus-artifactory-exporter
-version: 0.3.0
+version: 0.4.0
 keywords:
   - metrics
   - artifactory

--- a/charts/prometheus-artifactory-exporter/templates/deployment.yaml
+++ b/charts/prometheus-artifactory-exporter/templates/deployment.yaml
@@ -34,6 +34,9 @@ spec:
           args:
             - "--log.level={{ .Values.options.logLevel }}"
             - "--log.format={{ .Values.options.logFormat }}"
+          {{- range $metric := .Values.options.optionalMetrics }}
+            - "--optional-metric={{ $metric }}"
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/prometheus-artifactory-exporter/values.yaml
+++ b/charts/prometheus-artifactory-exporter/values.yaml
@@ -19,7 +19,7 @@ image:
   registry: ghcr.io
   repository: peimanja/artifactory_exporter
   # set to canary for the latest unreleased version
-  tag: v1.9.5
+  tag: v1.10.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -44,6 +44,10 @@ options:
   telemetryPath: /metrics
   verifySSL: false
   timeout: 5s
+  # Some metrics are expensive to collect, so they are disabled by default.
+  # visit https://github.com/peimanja/artifactory_exporter#optional-metrics for more details
+  optionalMetrics: []
+    # - replication_status
 
 service:
   type: ClusterIP


### PR DESCRIPTION
#### What this PR does / why we need it:
Optional metrics have been added to the exporter in https://github.com/peimanja/artifactory_exporter/pull/88. Here we are adding to enable that option in the chart

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-artifactory-exporter]`)
