### PR TITLE
[prometheus-artifactory-exporter] Bump the exporter version to 1.13.2

### DIFF
--- a/charts/prometheus-artifactory-exporter/Chart.yaml
+++ b/charts/prometheus-artifactory-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.13.0"
+appVersion: "1.13.2"
 description: A Helm chart for the Prometheus Artifactory Exporter
 name: prometheus-artifactory-exporter
-version: 0.6.0
+version: 0.6.1
 keywords:
   - metrics
   - artifactory

--- a/charts/prometheus-artifactory-exporter/values.yaml
+++ b/charts/prometheus-artifactory-exporter/values.yaml
@@ -19,7 +19,7 @@ image:
   registry: ghcr.io
   repository: peimanja/artifactory_exporter
   # set to canary for the latest unreleased version
-  tag: v1.13.0
+  tag: v1.13.2
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
#### What this PR does / why we need it:
* Bump the exporter version to [v1.13.2](https://github.com/peimanja/artifactory_exporter/releases/tag/v1.13.2)

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-artifactory-exporter]`)
