### PR TITLE
[prometheus-artifactory-exporter] feat: support reading an external secret

### DIFF
--- a/charts/prometheus-artifactory-exporter/Chart.yaml
+++ b/charts/prometheus-artifactory-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.13.2"
 description: A Helm chart for the Prometheus Artifactory Exporter
 name: prometheus-artifactory-exporter
-version: 0.6.1
+version: 0.7.0
 keywords:
   - metrics
   - artifactory

--- a/charts/prometheus-artifactory-exporter/templates/deployment.yaml
+++ b/charts/prometheus-artifactory-exporter/templates/deployment.yaml
@@ -72,8 +72,11 @@ spec:
               value: {{ .Values.options.timeout| quote }}
           envFrom:
             - secretRef:
+          {{- if .Values.artifactory.secret.create }}
                 name: {{ template "prometheus-artifactory-exporter.secret" . }}
-
+          {{- else -}}
+                name: {{ .Values.artifactory.secret.name }}
+          {{- end }}
         {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/prometheus-artifactory-exporter/templates/secret-env.yaml
+++ b/charts/prometheus-artifactory-exporter/templates/secret-env.yaml
@@ -1,5 +1,5 @@
 
-{{- if or (not .Values.artifactory.existingSecret) }}
+{{- if .Values.artifactory.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/prometheus-artifactory-exporter/values.yaml
+++ b/charts/prometheus-artifactory-exporter/values.yaml
@@ -35,7 +35,9 @@ artifactory:
   user: ""
   pass: ""
   accessToken: "xxxxxxxxxxxxxxxxxxxxxxxx"
-  existingSecret: false
+  secret:
+    create: true
+    name: "" 
 
 # visit https://github.com/peimanja/artifactory_exporter#flags
 options:


### PR DESCRIPTION
<!--
Thank you for contributing to peimanja/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This adds support for ingesting a secret provided outside of the Helm release for authentication with Artifactory. For example, using an `ExternalSecret` to grab the credentials from Vault, and allowing the exporter to read from the generated secret owned by the external-secrets controller.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-artifactory-exporter]`)
