### PR TITLE
[prometheus-artifactory-exporter] Bump the exporter version to 1.14.0

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@master
         with:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -18,7 +18,8 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: '3.10'
+          check-latest: true
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.0

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -7,21 +7,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
         with:
           version: v3.8.1
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -41,7 +41,7 @@ jobs:
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.4.0
+        uses: helm/kind-action@v1
 
         if: steps.list-changed.outputs.changed == 'true'
       - name: Run chart-testing (install)

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v4.0.0
         with:
           version: v3.8.1
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Lint Code Base
-        uses: docker://github/super-linter:v3.12.0
+        uses: docker://github/super-linter:v6.1.1
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_BASH: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Lint Code Base
-        uses: docker://github/super-linter:v6.1.1
+        uses: docker://ghcr.io/super-linter/super-linter:v6.1.1
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_BASH: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Lint Code Base
         uses: docker://ghcr.io/super-linter/super-linter:v6.1.1

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: docker://ghcr.io/super-linter/super-linter:v6.1.1
+        uses: docker://github/super-linter:v3.12.0
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_BASH: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Fetch history
         run: git fetch --prune --unshallow
@@ -21,9 +21,9 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v4.0.0
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0

--- a/charts/prometheus-artifactory-exporter/Chart.yaml
+++ b/charts/prometheus-artifactory-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.13.2"
+appVersion: "1.14.0"
 description: A Helm chart for the Prometheus Artifactory Exporter
 name: prometheus-artifactory-exporter
-version: 0.6.1
+version: 0.6.2
 keywords:
   - metrics
   - artifactory

--- a/charts/prometheus-artifactory-exporter/values.yaml
+++ b/charts/prometheus-artifactory-exporter/values.yaml
@@ -19,7 +19,7 @@ image:
   registry: ghcr.io
   repository: peimanja/artifactory_exporter
   # set to canary for the latest unreleased version
-  tag: v1.13.2
+  tag: v1.14.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -50,6 +50,7 @@ options:
     # - artifacts # enables artifactory_artifacts_* metrics
     # - replication_status # adds the `status` label to `artifactory_replication_enabled` metric
     # - federation_status # enables `artifactory_federation_*` metrics
+    # - open_metrics # exposes pen Metrics from the JFrog Platform
 
 service:
   type: ClusterIP

--- a/ct.yaml
+++ b/ct.yaml
@@ -5,4 +5,3 @@ chart-dirs:
   - charts
 chart-repos:
   - peimanja=https://peimanja.github.io/helm-charts
-helm-extra-args: --timeout 600s


### PR DESCRIPTION
#### What this PR does / why we need it:
* Bump the exporter version to [v1.14.0](https://github.com/peimanja/artifactory_exporter/releases/tag/v1.14.0)
* Add `open_metrics` to the list of optional metrics

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-artifactory-exporter]`)