### PR TITLE
[prometheus-artifactory-exporter] add image pull secrets

### DIFF
--- a/charts/prometheus-artifactory-exporter/Chart.yaml
+++ b/charts/prometheus-artifactory-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.14.0"
 description: A Helm chart for the Prometheus Artifactory Exporter
 name: prometheus-artifactory-exporter
-version: 0.6.2
+version: 0.7.0
 keywords:
   - metrics
   - artifactory

--- a/charts/prometheus-artifactory-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-artifactory-exporter/templates/_helpers.tpl
@@ -63,3 +63,20 @@ Secret name for Artifactory credentials
         {{ template "prometheus-artifactory-exporter.fullname" . }}
     {{- end -}}
 {{- end -}}
+
+{{/*
+Resolve imagePullSecrets value
+*/}}
+{{- define "prometheus-artifactory-exporter.imagePullSecrets" -}}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/prometheus-artifactory-exporter/templates/deployment.yaml
+++ b/charts/prometheus-artifactory-exporter/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     {{- end }}
     spec:
     {{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
-{{- include "artifactory.imagePullSecrets" . | indent 6 }}
+{{- include "prometheus-artifactory-exporter.imagePullSecrets" . | indent 6 }}
     {{- end }}
       serviceAccountName: {{ template "prometheus-artifactory-exporter.serviceAccountName" . }}
       {{- with .Values.initContainers }}

--- a/charts/prometheus-artifactory-exporter/templates/deployment.yaml
+++ b/charts/prometheus-artifactory-exporter/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         {{ toYaml .Values.podAnnotations | nindent 8 }}
     {{- end }}
     spec:
+    {{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
+{{- include "artifactory.imagePullSecrets" . | indent 6 }}
+    {{- end }}
       serviceAccountName: {{ template "prometheus-artifactory-exporter.serviceAccountName" . }}
       {{- with .Values.initContainers }}
       initContainers: {{ toYaml . | nindent 8 }}

--- a/charts/prometheus-artifactory-exporter/values.yaml
+++ b/charts/prometheus-artifactory-exporter/values.yaml
@@ -1,3 +1,7 @@
+global: {}
+  # imagePullSecrets:
+  #   - myRegistryKeySecretName
+
 # Default values for artifactory-exporter.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -21,6 +25,9 @@ image:
   # set to canary for the latest unreleased version
   tag: v1.14.0
   pullPolicy: IfNotPresent
+
+# imagePullSecrets:
+#   - myRegistryKeySecretName
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
<!--
Thank you for contributing to peimanja/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Inspiration taken from https://github.com/jfrog/charts/tree/master/stable/artifactory, this PR will help people to pull the image from a private registry 


#### Which issue this PR fixes
  - fixes #16

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-artifactory-exporter]`)
