### PR TITLE
[prometheus-artifactory-exporter] Allow setting additional labels on deployment and pods

### DIFF
--- a/charts/prometheus-artifactory-exporter/Chart.yaml
+++ b/charts/prometheus-artifactory-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.14.0"
 description: A Helm chart for the Prometheus Artifactory Exporter
 name: prometheus-artifactory-exporter
-version: 0.6.3
+version: 0.6.4
 keywords:
   - metrics
   - artifactory

--- a/charts/prometheus-artifactory-exporter/templates/deployment.yaml
+++ b/charts/prometheus-artifactory-exporter/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "prometheus-artifactory-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- with .Values.extraDeploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -18,6 +21,9 @@ spec:
       labels:
         app: {{ template "prometheus-artifactory-exporter.name" . }}
         release: {{ .Release.Name }}
+        {{- with .Values.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     {{- if .Values.podAnnotations }}
       annotations:
         {{ toYaml .Values.podAnnotations | nindent 8 }}

--- a/charts/prometheus-artifactory-exporter/values.yaml
+++ b/charts/prometheus-artifactory-exporter/values.yaml
@@ -117,10 +117,10 @@ initContainers: []
 extraContainers: []
 
 # Extra labels for the exporter deployment
-extraDeploymentLabels:  {}
+extraDeploymentLabels: {}
 
 # Extra labels for the exporter pod
-extraPodLabels:  {}
+extraPodLabels: {}
 
 # Extra Volumes for the pod
 extraVolumes: []

--- a/charts/prometheus-artifactory-exporter/values.yaml
+++ b/charts/prometheus-artifactory-exporter/values.yaml
@@ -116,6 +116,12 @@ initContainers: []
 # Extra containers for the exporter pod
 extraContainers: []
 
+# Extra labels for the exporter deployment
+extraDeploymentLabels:  {}
+
+# Extra labels for the exporter pod
+extraPodLabels:  {}
+
 # Extra Volumes for the pod
 extraVolumes: []
 # - name: example


### PR DESCRIPTION
<!--
Thank you for contributing to peimanja/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

- Adds `extraDeploymentLabels` that will add additional labels to the deployment
- Adds `extraPodLabels` that will add additional labels on the pod

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
 
fixes #22 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-artifactory-exporter]`)
