### PR TITLE
[prometheus-artifactory-exporter] Add option to configure JFrog Access Federation validation through Helm

### DIFF
--- a/charts/prometheus-artifactory-exporter/Chart.yaml
+++ b/charts/prometheus-artifactory-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.15.0"
 description: A Helm chart for the Prometheus Artifactory Exporter
 name: prometheus-artifactory-exporter
-version: 0.6.5
+version: 0.7.0
 keywords:
   - metrics
   - artifactory

--- a/charts/prometheus-artifactory-exporter/Chart.yaml
+++ b/charts/prometheus-artifactory-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.14.0"
 description: A Helm chart for the Prometheus Artifactory Exporter
 name: prometheus-artifactory-exporter
-version: 0.6.4
+version: 0.6.5
 keywords:
   - metrics
   - artifactory

--- a/charts/prometheus-artifactory-exporter/Chart.yaml
+++ b/charts/prometheus-artifactory-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.14.0"
+appVersion: "1.15.0"
 description: A Helm chart for the Prometheus Artifactory Exporter
 name: prometheus-artifactory-exporter
 version: 0.6.5

--- a/charts/prometheus-artifactory-exporter/templates/deployment.yaml
+++ b/charts/prometheus-artifactory-exporter/templates/deployment.yaml
@@ -76,6 +76,8 @@ spec:
               value: {{ .Values.options.verifySSL | quote }}
             - name: ARTI_TIMEOUT
               value: {{ .Values.options.timeout| quote }}
+            - name: ACCESS_FEDERATION_TARGET
+              value: {{ .Values.options.accessFederationTarget | quote }}
           envFrom:
             - secretRef:
                 name: {{ template "prometheus-artifactory-exporter.secret" . }}

--- a/charts/prometheus-artifactory-exporter/values.yaml
+++ b/charts/prometheus-artifactory-exporter/values.yaml
@@ -51,6 +51,8 @@ options:
     # - replication_status # adds the `status` label to `artifactory_replication_enabled` metric
     # - federation_status # enables `artifactory_federation_*` metrics
     # - open_metrics # exposes pen Metrics from the JFrog Platform
+    # - access_federation_validate # enables JFrog Access Federation validation status metric
+  accessFederationTarget: ""
 
 service:
   type: ClusterIP


### PR DESCRIPTION
<!--
Thank you for contributing to peimanja/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Adds options to configure optional metric `access_federation_valid` and its corresponding parameter `access-federation-target` as potentially introduced by https://github.com/peimanja/artifactory_exporter/pull/154.

#### Special notes for your reviewer:
https://github.com/peimanja/artifactory_exporter/pull/154 is required for this PR.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-artifactory-exporter]`)
