### PR TITLE
[prometheus-artifactory-exporter] - add securityContext to helm chart

### DIFF
--- a/charts/prometheus-artifactory-exporter/Chart.yaml
+++ b/charts/prometheus-artifactory-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.15.1"
 description: A Helm chart for the Prometheus Artifactory Exporter
 name: prometheus-artifactory-exporter
-version: 0.7.1
+version: 0.8.0
 keywords:
   - metrics
   - artifactory

--- a/charts/prometheus-artifactory-exporter/templates/deployment.yaml
+++ b/charts/prometheus-artifactory-exporter/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
           {{- range $metric := .Values.options.optionalMetrics }}
             - "--optional-metric={{ $metric }}"
           {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/prometheus-artifactory-exporter/templates/deployment.yaml
+++ b/charts/prometheus-artifactory-exporter/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
       {{- with .Values.initContainers }}
       initContainers: {{ toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/prometheus-artifactory-exporter/values.yaml
+++ b/charts/prometheus-artifactory-exporter/values.yaml
@@ -103,6 +103,21 @@ serviceMonitor:
 
 priorityClassName: ""
 
+podSecurityContext: {}
+# fsGroup: 1000
+
+## User and Group to run artifactory-exporter container as
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop: ["ALL"]
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
<!--
Thank you for contributing to peimanja/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

#### Which issue this PR fixes

This PR indroduces the securityContext and podSecurityContext settings for the helmchart
```
securityContext:
  runAsUser: 1000
  runAsGroup: 1000
  readOnlyRootFilesystem: true
  runAsNonRoot: true
  allowPrivilegeEscalation: false
  seccompProfile:
    type: RuntimeDefault
  capabilities:
    drop: ["ALL"]
```

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-artifactory-exporter]`)
