### PR TITLE
[prometheus-artifactory-exporter] - bump helm chart version to 0.9.0

### DIFF
--- a/charts/prometheus-artifactory-exporter/Chart.yaml
+++ b/charts/prometheus-artifactory-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.15.1"
+appVersion: "1.16.0"
 description: A Helm chart for the Prometheus Artifactory Exporter
 name: prometheus-artifactory-exporter
-version: 0.8.1
+version: 0.9.0
 keywords:
   - metrics
   - artifactory

--- a/charts/prometheus-artifactory-exporter/templates/deployment.yaml
+++ b/charts/prometheus-artifactory-exporter/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
     {{- end }}
     spec:
     {{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
-    {{- include "prometheus-artifactory-exporter.imagePullSecrets" . | indent 6 }}
+{{- include "prometheus-artifactory-exporter.imagePullSecrets" . | indent 6 }}
     {{- end }}
       serviceAccountName: {{ template "prometheus-artifactory-exporter.serviceAccountName" . }}
       {{- with .Values.initContainers }}

--- a/charts/prometheus-artifactory-exporter/templates/deployment.yaml
+++ b/charts/prometheus-artifactory-exporter/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
     {{- end }}
     spec:
     {{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
-{{- include "prometheus-artifactory-exporter.imagePullSecrets" . | indent 6 }}
+    {{- include "prometheus-artifactory-exporter.imagePullSecrets" . | indent 6 }}
     {{- end }}
       serviceAccountName: {{ template "prometheus-artifactory-exporter.serviceAccountName" . }}
       {{- with .Values.initContainers }}
@@ -45,7 +45,7 @@ spec:
           args:
             - "--log.level={{ .Values.options.logLevel }}"
             - "--log.format={{ .Values.options.logFormat }}"
-            - "--use-cache={{ .Values.options.useCache | quote }}"
+            - "--use-cache={{ .Values.options.useCache | default false }}"
             - "--cache-timeout={{ .Values.options.cacheTimeout | default "30s" }}"
             - "--cache-ttl={{ .Values.options.cacheTTL | default "5m"}}"
           {{- range $metric := .Values.options.optionalMetrics }}

--- a/charts/prometheus-artifactory-exporter/templates/deployment.yaml
+++ b/charts/prometheus-artifactory-exporter/templates/deployment.yaml
@@ -45,9 +45,11 @@ spec:
           args:
             - "--log.level={{ .Values.options.logLevel }}"
             - "--log.format={{ .Values.options.logFormat }}"
-            - "--use-cache={{ .Values.options.useCache | default false }}"
+            {{- if .Values.options.useCache }}
+            - "--use-cache"
             - "--cache-timeout={{ .Values.options.cacheTimeout | default "30s" }}"
             - "--cache-ttl={{ .Values.options.cacheTTL | default "5m"}}"
+            {{- end }}
           {{- range $metric := .Values.options.optionalMetrics }}
             - "--optional-metric={{ $metric }}"
           {{- end }}

--- a/charts/prometheus-artifactory-exporter/templates/deployment.yaml
+++ b/charts/prometheus-artifactory-exporter/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
           args:
             - "--log.level={{ .Values.options.logLevel }}"
             - "--log.format={{ .Values.options.logFormat }}"
+            - "--use-cache={{ .Values.options.useCache }}"
+            - "--cache-timeout={{ .Values.options.cacheTimeout }}"
+            - "--cache-ttl={{ .Values.options.cacheTTL }}"
           {{- range $metric := .Values.options.optionalMetrics }}
             - "--optional-metric={{ $metric }}"
           {{- end }}

--- a/charts/prometheus-artifactory-exporter/templates/deployment.yaml
+++ b/charts/prometheus-artifactory-exporter/templates/deployment.yaml
@@ -45,9 +45,9 @@ spec:
           args:
             - "--log.level={{ .Values.options.logLevel }}"
             - "--log.format={{ .Values.options.logFormat }}"
-            - "--use-cache={{ .Values.options.useCache }}"
-            - "--cache-timeout={{ .Values.options.cacheTimeout }}"
-            - "--cache-ttl={{ .Values.options.cacheTTL }}"
+            - "--use-cache={{ .Values.options.useCache | quote }}"
+            - "--cache-timeout={{ .Values.options.cacheTimeout | default "30s" }}"
+            - "--cache-ttl={{ .Values.options.cacheTTL | default "5m"}}"
           {{- range $metric := .Values.options.optionalMetrics }}
             - "--optional-metric={{ $metric }}"
           {{- end }}

--- a/charts/prometheus-artifactory-exporter/values.yaml
+++ b/charts/prometheus-artifactory-exporter/values.yaml
@@ -23,7 +23,7 @@ image:
   registry: ghcr.io
   repository: peimanja/artifactory_exporter
   # set to canary for the latest unreleased version
-  tag: v1.15.1
+  tag: v1.16.0
   pullPolicy: IfNotPresent
 
 # imagePullSecrets:
@@ -67,7 +67,7 @@ service:
   annotations: {}
 
 ingress:
-  enabled: false
+  enabled: true
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
@@ -77,7 +77,7 @@ ingress:
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
-  #      - chart-example.local
+  #     - chart-example.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/prometheus-artifactory-exporter/values.yaml
+++ b/charts/prometheus-artifactory-exporter/values.yaml
@@ -51,6 +51,9 @@ options:
   telemetryPath: /metrics
   verifySSL: false
   timeout: 5s
+  useCache: false
+  cacheTimeout: 30s
+  cacheTTL: 5m
   # Some metrics are expensive to collect, so they are disabled by default.
   # visit https://github.com/peimanja/artifactory_exporter#optional-metrics for more details
   optionalMetrics: []

--- a/charts/prometheus-artifactory-exporter/values.yaml
+++ b/charts/prometheus-artifactory-exporter/values.yaml
@@ -70,7 +70,7 @@ service:
   annotations: {}
 
 ingress:
-  enabled: true
+  enabled: false
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the Artifactory Exporter Version in the Helm Chart to v1.16.0


#### Which issue this PR fixes
Application Changelog https://github.com/peimanja/artifactory_exporter/compare/v1.15.1...v1.16.0
#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-artifactory-exporter]`)
