### PR TITLE
[prometheus-artifactory-exporter] Bump appVersion to v1.16.1

### DIFF
--- a/charts/prometheus-artifactory-exporter/Chart.yaml
+++ b/charts/prometheus-artifactory-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.16.0"
+appVersion: "1.16.1"
 description: A Helm chart for the Prometheus Artifactory Exporter
 name: prometheus-artifactory-exporter
-version: 0.9.0
+version: 0.9.1
 keywords:
   - metrics
   - artifactory


### PR DESCRIPTION
This pull request updates the Helm chart for the Prometheus Artifactory Exporter to a new patch version, reflecting an upgrade of the underlying application.

- Version bump:
  * Updated `appVersion` from "1.16.0" to [1.16.1](https://github.com/peimanja/artifactory_exporter/releases/tag/v1.16.1) and chart `version` from "0.9.0" to "0.9.1" in `charts/prometheus-artifactory-exporter/Chart.yaml` to track the latest application release.