### PR TITLE
[prometheus-artifactory-exporter] add podmonitoring for gke clusters

### DIFF
--- a/charts/prometheus-artifactory-exporter/Chart.yaml
+++ b/charts/prometheus-artifactory-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.15.1"
+appVersion: "1.16.1"
 description: A Helm chart for the Prometheus Artifactory Exporter
 name: prometheus-artifactory-exporter
-version: 0.8.1
+version: 0.9.2
 keywords:
   - metrics
   - artifactory

--- a/charts/prometheus-artifactory-exporter/templates/podmonitoring.yaml
+++ b/charts/prometheus-artifactory-exporter/templates/podmonitoring.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.podMonitoring.enabled }}
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: {{ template "prometheus-artifactory-exporter.fullname" $ }}
+  labels:
+    {{- if or $.Values.podMonitoring.defaults.labels .labels }}
+    {{- toYaml (.labels | default $.Values.podMonitoring.defaults.labels) | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - port: http
+    scheme: {{ $.Values.podMonitoring.scheme }}
+    {{- if $.Values.podMonitoring.tlsConfig }}
+    tls: {{ toYaml $.Values.podMonitoring.tlsConfig | nindent 6 }}
+    {{- end }}
+    path: {{ $.Values.podMonitoring.path }}
+    interval: {{ .interval | default $.Values.podMonitoring.defaults.interval }}
+    timeout: {{ .scrapeTimeout | default $.Values.podMonitoring.defaults.scrapeTimeout }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-artifactory-exporter.name" . }}
+{{- end }}

--- a/charts/prometheus-artifactory-exporter/values.yaml
+++ b/charts/prometheus-artifactory-exporter/values.yaml
@@ -113,6 +113,39 @@ priorityClassName: ""
 podSecurityContext: {}
 # fsGroup: 1000
 
+podMonitoring:
+  ## If true, a PodMonitoring CR is created for google managed prometheus
+  ## https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#gmp-pod-monitoring
+  ##
+  selfMonitor:
+    enabled: false
+    additionalMetricsRelabels: {}
+    labels: {}
+    path: /metrics
+    interval: 30s
+    scrapeTimeout: 30s
+
+  ## If true, a PodMonitoring CR is created for a google managed prometheus
+  ## https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#gmp-pod-monitoring for each target
+  ##
+  enabled: false
+
+  ## Default values that will be used for all PodMonitoring created by `targets`
+  ## Following PodMonitoring API specs https://github.com/GoogleCloudPlatform/prometheus-engine/blob/main/doc/api.md#scrapeendpoint
+  defaults:
+    additionalMetricsRelabels: {}
+    labels: {}
+    interval: 30s
+    scrapeTimeout: 30s
+    module: http_2xx
+  ## scheme: Protocol scheme to use to scrape.
+  scheme: http
+  ## path: HTTP path. Needs to be adjusted, if web.route-prefix is set
+  path: "/probe"
+  ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
+  ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
+  tlsConfig: {}
+
 ## User and Group to run artifactory-exporter container as
 securityContext:
   runAsUser: 1000


### PR DESCRIPTION
<!--
Thank you for contributing to peimanja/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Introduce Podmonitoring resource to deploy artifactory exporter in GKE Clusters with managed prometheus

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-artifactory-exporter]`)
